### PR TITLE
feat(store): add the option to disable constraints on create

### DIFF
--- a/dynastore_test.go
+++ b/dynastore_test.go
@@ -44,6 +44,13 @@ func TestCreate(t *testing.T) {
 	res, err := store.Create(context.Background(), part, "sort1", []byte("data"), store.WriteWithTTL(10*time.Second))
 	assert.NoError(err)
 	assert.Equal(int64(1), res.Version)
+
+	res, err = store.Create(context.Background(), part, "sort1", []byte("data"), store.WriteWithTTL(10*time.Second))
+	assert.Error(err)
+
+	res, err = store.Create(context.Background(), part, "sort1", []byte("data"), store.WriteWithTTL(10*time.Second), store.WriteWithCreateConstraintDisabled(true))
+	assert.NoError(err)
+	assert.Equal(int64(2), res.Version)
 }
 
 func TestGet(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -42,9 +42,10 @@ type WriteOption[P Key, S Key, V any] interface {
 
 // options holds all available write configuration options
 type writeOptions[P Key, S Key, V any] struct {
-	extraFields map[string]any
-	ttl         time.Duration
-	version     int64
+	extraFields              map[string]any
+	ttl                      time.Duration
+	version                  int64
+	createConstraintDisabled bool
 }
 
 // writeOptionFunc wraps a function and implements the WriteOption interface
@@ -80,6 +81,13 @@ func writeWithVersion[P Key, S Key, V any](version int64) WriteOption[P, S, V] {
 func writeWithExtraFields[P Key, S Key, V any](extraFields map[string]any) WriteOption[P, S, V] {
 	return writeOptionFunc[P, S, V](func(opts *writeOptions[P, S, V]) {
 		opts.extraFields = extraFields
+	})
+}
+
+// WriteWithCreateConstraintDisabled disable the check on create for existence of the rows
+func writeWithCreateConstraintDisabled[P Key, S Key, V any](createConstraintDisabled bool) WriteOption[P, S, V] {
+	return writeOptionFunc[P, S, V](func(opts *writeOptions[P, S, V]) {
+		opts.createConstraintDisabled = createConstraintDisabled
 	})
 }
 


### PR DESCRIPTION
This enables users to create or update records using the create method.
